### PR TITLE
Fixed createDatabaseHelper.py

### DIFF
--- a/api.py
+++ b/api.py
@@ -1,7 +1,7 @@
 """
 By Samir and Adrian Marin Estrada
 """
-
+from createDatabaseHelper import list_of_files
 from flask import Flask
 from flask_restful import Resource, Api
 
@@ -12,6 +12,15 @@ class Dedomena(Resource):
     def get(self):
         return {'hello': 'dedomena'}
 
+# path_name is a string
+# gets list of files
+class CreateDatabase(Resource):
+	def get(self, path_name):
+		# print(path_name)
+		return list_of_files(path_name)
+		# return "Hello!"
+
+api.add_resource(CreateDatabase,'/<string:path_name>')
 api.add_resource(Dedomena, '/')
 
 if __name__ == '__main__':

--- a/createDatabaseHelper.py
+++ b/createDatabaseHelper.py
@@ -1,0 +1,21 @@
+# from os import walk
+import os
+from os.path import join, normpath
+
+def list_of_files(path_name):
+
+	pathname_modified = path_name.replace('+', '/')
+
+
+	list_of_files = []
+
+	for dirpath, dirnames, filenames in os.walk(pathname_modified):
+		list_of_files.extend(filenames)
+		# print(list_of_files)
+		# print(filenames)
+		return list_of_files
+
+	return list_of_files
+
+
+# list_of_files("/drives/c/Users/adria/cmpt/bro_workfolder/dedomena/")


### PR DESCRIPTION
Note: requires linux/unix based file system to work.
Currently returns names of files at specified path, should os.walk fail returns empty list.

Previously:
creating "createDatabaseHelper" function (work in progress)

Eventually should be in a seperate branch. Note: Currently not itterating through the for loop using os.walk. Perhaps because being used on Windows OS.